### PR TITLE
This commit Fixes an issue with translations for scopes (ej. reverse_name)

### DIFF
--- a/lib/meta_search/model_compatibility.rb
+++ b/lib/meta_search/model_compatibility.rb
@@ -64,7 +64,7 @@ module MetaSearch
       defaults << options.delete(:default) if options[:default]
       defaults << attribute.to_s.humanize
 
-      options.reverse_merge! :count => 1, :default => defaults, :attribute => klass.human_attribute_name(predicate_attribute)
+      options.reverse_merge! :count => 1, :default => defaults, :attribute => klass.human_attribute_name(predicate_attribute || attribute)
       I18n.translate(defaults.shift, options)
     end
   end

--- a/test/locales/flanders.yml
+++ b/test/locales/flanders.yml
@@ -7,5 +7,7 @@ flanders:
     predicates:
       contains: "%{attribute} contains-diddly"
     attributes:
+      company:
+        reverse_name: "Company reverse name-diddly"
       developer:
         name_contains: "Developer name-diddly contains-aroonie"

--- a/test/test_view_helpers.rb
+++ b/test/test_view_helpers.rb
@@ -60,6 +60,7 @@ class TestViewHelpers < ActionView::TestCase
 
       should "localize according to their bases" do
         assert_match /Company name-diddly contains-diddly/, @f1.label(:name_contains)
+        assert_match /Company reverse name-diddly/, @f1.label(:reverse_name)
         assert_match /Developer name-diddly contains-aroonie/, @f2.label(:name_like)
       end
     end


### PR DESCRIPTION
Basically, if you had an scope it would try to call `klass.human_attribute_name(predicate_attribute)` with predicate_attribute in nil (wich breaks with a weird message from I18n)

any comment will be appreciated.
