### PR TITLE
undefined method `scan' for nil:NilClass

### DIFF
--- a/lib/meta_search/builder.rb
+++ b/lib/meta_search/builder.rb
@@ -174,7 +174,7 @@ module MetaSearch
     def set_sort(val)
       column, direction = val.split('.')
       direction ||= 'asc'
-      if ['asc','desc'].include?(direction)
+      if not column.nil? and ['asc','desc'].include?(direction)
         if @base.respond_to?("sort_by_#{column}_#{direction}")
           search_attributes['meta_sort'] = val
           @relation = @relation.send("sort_by_#{column}_#{direction}")

--- a/test/test_search.rb
+++ b/test/test_search.rb
@@ -86,6 +86,18 @@ class TestSearch < Test::Unit::TestCase
         end
       end
 
+      context "when meta_sort value is empty string" do
+        setup do
+          @s.meta_sort = ''
+        end
+
+        should "not raise an error, just ignore sorting" do
+          assert_nothing_raised do
+            assert_equal Company.all, @s.all
+          end
+        end
+      end
+
       context "sorted by name in ascending order" do
         setup do
           @s.meta_sort = 'name.asc'


### PR DESCRIPTION
Exception

```
undefined method `scan' for nil:NilClass
```

Backtrace

```
activesupport (3.0.3) lib/active_support/whiny_nil.rb:48:in `method_missing'
meta_search (0.9.10) lib/meta_search/builder.rb:184:in `set_sort'
meta_search (0.9.10) lib/meta_search/builder.rb:137:in `method_missing'
meta_search (0.9.10) lib/meta_search/builder.rb:126:in `block in assign_attributes'
meta_search (0.9.10) lib/meta_search/builder.rb:125:in `each_pair'
meta_search (0.9.10) lib/meta_search/builder.rb:125:in `assign_attributes'
meta_search (0.9.10) lib/meta_search/builder.rb:100:in `build'
meta_search (0.9.10) lib/meta_search/searches/active_record.rb:32:in `metasearch'
```

Parameters

```
{"search"=>{"meta_sort"=>""},  "commit"=>"Search"}
```
