### PR TITLE
Add an optional ":join" parameter to multiparameter_field

### DIFF
--- a/lib/meta_search/helpers/form_builder.rb
+++ b/lib/meta_search/helpers/form_builder.rb
@@ -41,20 +41,20 @@ module MetaSearch
       def multiparameter_field(method, *args)
         defaults = has_multiparameter_defaults?(args) ? args.pop : {}
         raise ArgumentError, "No multiparameter fields specified" if args.blank?
-        html = ''.html_safe
+        join_str = defaults.delete(:join) || ''
+        html = []
         args.each_with_index do |field, index|
           type = field.delete(:field_type) || raise(ArgumentError, "No :field_type specified.")
           cast = field.delete(:type_cast) || ''
           opts = defaults.merge(field)
-          html.safe_concat(
+          html <<
             @template.send(
               type.to_s,
               @object_name,
               (method.to_s + "(#{index + 1}#{cast})"),
               objectify_options(opts))
-            )
         end
-        html
+        html.join(join_str).html_safe
       end
 
       # Behaves almost exactly like the select method, but instead of generating a select tag,

--- a/test/test_view_helpers.rb
+++ b/test/test_view_helpers.rb
@@ -81,7 +81,7 @@ class TestViewHelpers < ActionView::TestCase
     end
   end
 
-  context "A form using mutiparameter_field with default size option" do
+  context "A form using multiparameter_field with default size option" do
     setup do
       @s = Developer.search
       form_for @s do |f|
@@ -95,6 +95,18 @@ class TestViewHelpers < ActionView::TestCase
              {:field_type => :text_field, :type_cast => 'i'}, :size => 10
       assert_dom_equal '<input id="search_salary_in(1i)" name="search[salary_in(1i)]" ' +
                        'size="10" type="text" />' +
+                       '<input id="search_salary_in(2i)" name="search[salary_in(2i)]" ' +
+                       'size="10" type="text" />',
+                       html
+    end
+
+    should "join multiple fields together using a specified string" do
+      html = @f.multiparameter_field :salary_in,
+             {:field_type => :text_field, :type_cast => 'i'},
+             {:field_type => :text_field, :type_cast => 'i'}, :size => 10, :join => " and "
+      assert_dom_equal '<input id="search_salary_in(1i)" name="search[salary_in(1i)]" ' +
+                       'size="10" type="text" />' +
+                       ' and ' +
                        '<input id="search_salary_in(2i)" name="search[salary_in(2i)]" ' +
                        'size="10" type="text" />',
                        html


### PR DESCRIPTION
I wanted this in a personal project to separate two `between` fields with " and " or " - ", for example.
