### PR TITLE
[#18] Ability to configure join type

### DIFF
--- a/test/fixtures/developers.yml
+++ b/test/fixtures/developers.yml
@@ -53,3 +53,10 @@ another:
   name      : Another Guy
   salary    : 80000
   slacker   : false
+
+forgetful:
+  id        : 9
+  company_id: 3
+  name      : Forgetful Notetaker
+  salary    : 40000
+  slacker   : false

--- a/test/test_search.rb
+++ b/test/test_search.rb
@@ -74,6 +74,52 @@ class TestSearch < Test::Unit::TestCase
     end
   end
 
+  context "A Developer search" do
+    setup do
+      @s = Developer.search({:name_equals=>"Forgetful Notetaker"})
+    end
+
+    context "without any opts" do
+      should "find a null entry when searching notes" do
+        assert_equal 1, @s.notes_note_is_null(true).all.size
+      end
+
+      should "find no non-null entry when searching notes" do
+        assert_equal 0, @s.notes_note_is_not_null(true).all.size
+      end
+    end
+
+    context "with outer join specified" do
+      setup do
+        @s = Developer.search({:name_equals=>"Forgetful Notetaker"}, :join_type=>:outer)
+      end
+
+      should "find a null entry when searching notes" do
+        assert_equal 1, @s.notes_note_is_null(true).all.size
+      end
+
+      should "find no non-null entry when searching notes" do
+        assert_equal 0, @s.notes_note_is_not_null(true).all.size
+      end
+    end
+
+    context "with inner join specified" do
+      setup do
+        @s = Developer.search({:name_equals=>"Forgetful Notetaker"}, :join_type=>:inner)
+      end
+
+      should "find no null entry when searching notes" do
+        assert_equal 0, @s.notes_note_is_null(true).all.size
+      end
+
+      should "find no non-null entry when searching notes" do
+        assert_equal 0, @s.notes_note_is_not_null(true).all.size
+      end
+    end
+
+
+  end
+
   [{:name => 'Company', :object => Company},
    {:name => 'Company as a Relation', :object => Company.scoped}].each do |object|
     context_a_search_against object[:name], object[:object] do
@@ -477,8 +523,8 @@ class TestSearch < Test::Unit::TestCase
           @s.name_ne = 'Ernie Miller'
         end
 
-        should "return seven results" do
-          assert_equal 7, @s.all.size
+        should "return eight results" do
+          assert_equal 8, @s.all.size
         end
 
         should "not return a developer named Ernie Miller" do


### PR DESCRIPTION
For what I'm doing it was nicer to be able to configure join type when initializing the search, not globally at the MetaSearch level (which I think is what you meant by your suggestion, correct me if I'm wrong). 

Anyway, I added in that capability, so please pull it if you think it's useful. I included a few simple tests.

---

Adding a :join_type option to the builder initializer, which allows you to toggle inner vs outer join

Outer (default, but can specify):
@s = Developer.search({:name_equals=>"Forgetful Notetaker"}, :join_type=>:outer)

Inner:
@s = Developer.search({:name_equals=>"Forgetful Notetaker"}, :join_type=>:inner)

(also accepts strings: case-insensitive). 

If you give it something else, it will assume it is a real join object (like Arel::Nodes::InnerJoin)
