### PR TITLE
Cleans up apply_form_for_options! else statement 

### DIFF
--- a/lib/meta_search/helpers/form_helper.rb
+++ b/lib/meta_search/helpers/form_helper.rb
@@ -8,8 +8,7 @@ module MetaSearch
         elsif object_or_array.is_a?(Array) && (builder = object_or_array.detect {|o| o.is_a?(MetaSearch::Builder)})
           options[:url] ||= polymorphic_path(object_or_array.map {|o| o.is_a?(MetaSearch::Builder) ? o.base : o})
         else
-          super 
-          return
+          return super
         end
 
         html_options = {


### PR DESCRIPTION
`return super` does exactly the same as `super` and `return` on separate lines. It's just cleaner this way.
