### PR TITLE
Use reorder instead of order to override default_scope order.

### DIFF
--- a/lib/meta_search/builder.rb
+++ b/lib/meta_search/builder.rb
@@ -169,14 +169,14 @@ module MetaSearch
           @relation = @relation.send("sort_by_#{column}_#{direction}")
         elsif attribute = get_attribute(column)
           search_attributes['meta_sort'] = val
-          @relation = @relation.order(attribute.send(direction).to_sql)
+          @relation = @relation.reorder(attribute.send(direction).to_sql)
         elsif column.scan('_and_').present?
           attribute_names = column.split('_and_')
           attributes = attribute_names.map {|n| get_attribute(n)}
           if attribute_names.size == attributes.compact.size # We found all attributes
             search_attributes['meta_sort'] = val
             attributes.each do |attribute|
-              @relation = @relation.order(attribute.send(direction).to_sql)
+              @relation = @relation.reorder(attribute.send(direction).to_sql)
             end
           end
         end


### PR DESCRIPTION
Only other way to override default scope order AND keep power of meta_search ordering would be:
ModelClass.reorder(true).search(.....) which seems a bit awful to me, and may explode for some databases.
