### PR TITLE
ActiveRecord agnosticism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source :rubygems
 
 gem "activerecord", "~> 3.1"
 gem "activesupport", "~> 3.1"
-gem "polyamorous", "~> 0.5.0"
+gem "polyamorous", ">= 0.5.0"
 gem "actionpack", "~> 3.1"
 
 group :development do

--- a/lib/meta_search.rb
+++ b/lib/meta_search.rb
@@ -43,16 +43,20 @@ module MetaSearch
   ]
 end
 
-require 'active_record'
-require 'active_support'
-require 'action_view'
-require 'action_controller'
 require 'meta_search/searches/active_record'
 require 'meta_search/helpers'
 
 I18n.load_path += Dir[File.join(File.dirname(__FILE__), 'meta_search', 'locale', '*.yml')]
 
-ActiveRecord::Base.send(:include, MetaSearch::Searches::ActiveRecord)
-ActionView::Helpers::FormBuilder.send(:include, MetaSearch::Helpers::FormBuilder)
-ActionController::Base.helper(MetaSearch::Helpers::UrlHelper)
-ActionController::Base.helper(MetaSearch::Helpers::FormHelper)
+if defined?(::ActiveRecord)
+  ::ActiveRecord::Base.send(:include, MetaSearch::Searches::ActiveRecord)
+end
+
+if defined?(::ActionView)
+  ::ActionView::Helpers::FormBuilder.send(:include, MetaSearch::Helpers::FormBuilder)
+end
+
+if defined?(::ActionController)
+  ::ActionController::Base.helper(MetaSearch::Helpers::UrlHelper)
+  ::ActionController::Base.helper(MetaSearch::Helpers::FormHelper)
+end

--- a/meta_search.gemspec
+++ b/meta_search.gemspec
@@ -69,20 +69,20 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<activerecord>, ["~> 3.1"])
       s.add_runtime_dependency(%q<activesupport>, ["~> 3.1"])
-      s.add_runtime_dependency(%q<polyamorous>, ["~> 0.5.0"])
+      s.add_runtime_dependency(%q<polyamorous>, [">= 0.5.0"])
       s.add_runtime_dependency(%q<actionpack>, ["~> 3.1"])
       s.add_development_dependency(%q<shoulda>, ["~> 2.11"])
     else
       s.add_dependency(%q<activerecord>, ["~> 3.1"])
       s.add_dependency(%q<activesupport>, ["~> 3.1"])
-      s.add_dependency(%q<polyamorous>, ["~> 0.5.0"])
+      s.add_dependency(%q<polyamorous>, [">= 0.5.0"])
       s.add_dependency(%q<actionpack>, ["~> 3.1"])
       s.add_dependency(%q<shoulda>, ["~> 2.11"])
     end
   else
     s.add_dependency(%q<activerecord>, ["~> 3.1"])
     s.add_dependency(%q<activesupport>, ["~> 3.1"])
-    s.add_dependency(%q<polyamorous>, ["~> 0.5.0"])
+    s.add_dependency(%q<polyamorous>, [">= 0.5.0"])
     s.add_dependency(%q<actionpack>, ["~> 3.1"])
     s.add_dependency(%q<shoulda>, ["~> 2.11"])
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,6 +5,7 @@ require 'active_support/time'
 require 'active_record'
 require 'active_record/fixtures'
 require 'action_view'
+require 'action_controller'
 require 'meta_search'
 
 FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')


### PR DESCRIPTION
Currently meta_search forces a require of 'active_record', 'active_support', 'action_view', and 'action_controller' from within the initialization routine.

These should not be required explicitly by meta_search, and instead should be required by the user before requiring meta_search. This will allow the library to be used seamlessly with non-AR frameworks like Mongoid.